### PR TITLE
Fix: posix with fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "dnoegel/php-xdg-base-dir",
-    "description": "implementation of xdg base directory specification for php",
+    "name": "krageon/php-xdg-base-dir",
+    "description": "implementation of xdg base directory specification for php, uses posix_getuid when possible",
     "type": "library",
     "license": "MIT",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "krageon/php-xdg-base-dir",
-    "description": "implementation of xdg base directory specification for php, uses posix_getuid when possible",
+    "name": "dnoegel/php-xdg-base-dir",
+    "description": "implementation of xdg base directory specification for php",
     "type": "library",
     "license": "MIT",
     "require": {

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -101,7 +101,7 @@ class Xdg
         if (!$st['mode'] & self::S_IFDIR) {
             rmdir($fallback);
             $create = true;
-        } elseif ($st['uid'] != getmyuid() ||
+        } elseif ($st['uid'] != $this->getUid() ||
             $st['mode'] & (self::S_IRWXG | self::S_IRWXO)
         ) {
             rmdir($fallback);
@@ -114,5 +114,15 @@ class Xdg
 
         return $fallback;
     }
+
+    private function getUid()
+    {
+        if (function_exists('posix_getuid')) {
+            return posix_getuid();
+        }
+
+        return getmyuid();
+    }
+
 
 }


### PR DESCRIPTION
Uses `posix_getuid` instead of `getmyuid` whenever it is available. This is necessary because the person *running* the script is not necessarily the person that owns the script. Unfortunately the posix_* functions are not available everywhere, so I left it to fallback on to the old broken function.