### PR TITLE
Fix edge case

### DIFF
--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -27,7 +27,13 @@ class Xdg
      */
     public function getHomeConfigDir()
     {
-        $path = getenv('XDG_CONFIG_HOME') ?: $this->getHomeDir() . DIRECTORY_SEPARATOR . '.config';
+        if ($path = getenv('XDG_CONFIG_HOME')) {
+            return $path;
+        }
+
+        $homeDir = $this->getHomeDir();
+
+        $path = DIRECTORY_SEPARATOR === $homeDir ? $homeDir.'.config' : $homeDir . DIRECTORY_SEPARATOR . '.config';
 
         return $path;
     }


### PR DESCRIPTION
In a docker environment for example, it is not rare to have the homedir being `/` in which case the current code gives `//.config` instead of `/.config`.

It might not be the only occurrence and I didn't have time to test it further, but I'm opening this for the records :)